### PR TITLE
Fixed typo bite to byte

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+- '0.12'
 - '0.11'
 - '0.10'

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Convert a value in bytes to a more human-readable size.
 
 ####Example
 ```js
-> var biteSize = require("bite-size");
-> biteSize(10000)
+> var byteSize = require("byte-size");
+> byteSize(10000)
 '10 KB'
-> biteSize(10000, 1)
+> byteSize(10000, 1)
 '9.8 KB'
-> biteSize(10000, 2)
+> byteSize(10000, 2)
 '9.77 KB'
-> biteSize(10000, 3)
+> byteSize(10000, 3)
 '9.766 KB'
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "byte-size",
   "author": "Lloyd Brookes <75pound@gmail.com>",
+  "contributors": [{
+    "name": "Raul Perez",
+    "email": "repejota@gmail.com",
+    "url": "http://repejota.com"
+  }],
   "version": "0.1.0",
   "description": "Convert a value in bytes to a more human-readable size.",
   "repository": "https://github.com/75lb/byte-size.git",


### PR DESCRIPTION
Seems there is a typo on the README.md file that makes the documentation confusing.