### PR TITLE
Excludes development-only files from the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "license": "MIT",
   "description": "Convert a bytes (and octets) value to a more human-readable format. Choose between metric or IEC units.",
   "repository": "https://github.com/75lb/byte-size.git",
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "convert",
     "bytes",


### PR DESCRIPTION
Currently the npm package of this module includes some development-only files, for example `test.js` and `README.hbs`.

This PR excludes them from the package and reduce file size.
