### PR TITLE
Use precision for units from zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ class ByteSize {
           maximumFractionDigits: options.precision
         })
         const value = units.from === 0
-          ? prefix + bytes
+          ? prefix + defaultFormat.format(bytes)
           : prefix + defaultFormat.format(bytes / units.from)
         this.value = value
         this.unit = units.unit


### PR DESCRIPTION
Use precision when value is in first units range (from zero).

Thank you!